### PR TITLE
feat: add work board gallery

### DIFF
--- a/work-board/api/list-images.js
+++ b/work-board/api/list-images.js
@@ -1,0 +1,39 @@
+import { v2 as cloudinary } from 'cloudinary';
+
+cloudinary.config({
+  cloud_name: 'dazshqfrn',
+  api_key: process.env.CLOUDINARY_API_KEY,
+  api_secret: process.env.CLOUDINARY_API_SECRET
+});
+
+export default async function handler(req, res) {
+  try {
+    const result = await cloudinary.search
+      .expression('folder:work-board')
+      .with_field('context')
+      .with_field('metadata')
+      .max_results(500)
+      .execute();
+
+    const items = result.resources.map(r => ({
+      id: r.asset_id,
+      url: r.secure_url,
+      thumb: r.secure_url.replace('/upload/', '/upload/c_scale,w_300/'),
+      metadata: {
+        alt: r.context?.alt || '',
+        agileTeam: r.metadata?.agileTeam || '',
+        assetType: r.metadata?.assetType || '',
+        fileName: r.public_id.split('/').pop(),
+        status: r.metadata?.status || '',
+        user: r.metadata?.user || '',
+        fileURL: r.metadata?.fileURL || ''
+      }
+    }));
+
+    res.setHeader('Content-Type', 'application/json');
+    res.status(200).end(JSON.stringify(items));
+  } catch (err) {
+    console.error(err);
+    res.status(500).end(JSON.stringify({ error: 'Failed to fetch images' }));
+  }
+}

--- a/work-board/index.html
+++ b/work-board/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Work Board</title>
+  <link rel="stylesheet" href="work-board.css">
+</head>
+<body>
+  <header>
+    <h1>Work Board</h1>
+    <button id="refreshBtn">Refresh</button>
+    <input id="searchInput" placeholder="Search metadata..." />
+  </header>
+
+  <section id="filters"></section>
+
+  <main id="gallery"></main>
+
+  <div id="lightbox" class="hidden">
+    <div class="overlay"></div>
+    <div class="content">
+      <button id="closeLightbox">&times;</button>
+      <img id="lightboxImg" alt="" />
+      <ul id="metaList"></ul>
+      <a id="fileLink" target="_blank">Go to file</a>
+    </div>
+  </div>
+
+  <script type="module" src="work-board.js"></script>
+</body>
+</html>

--- a/work-board/work-board.css
+++ b/work-board/work-board.css
@@ -1,0 +1,12 @@
+body { font-family: sans-serif; margin: 0; }
+header { display: flex; gap: 1rem; align-items: center; padding: 1rem; background: #0A1324; color: white; }
+#filters { display: flex; flex-wrap: wrap; gap: 1rem; padding: 1rem; }
+.filter-group { display: flex; flex-direction: column; }
+#gallery { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px,1fr)); gap: 1rem; padding: 1rem; }
+.card img { width: 100%; height: auto; display: block; cursor: pointer; }
+
+#lightbox.hidden { display: none; }
+#lightbox .overlay { position: fixed; top: 0; left: 0; width: 100vw; height: 100vh; background: rgba(0,0,0,0.8); }
+#lightbox .content { position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); background: white; padding: 1rem; max-width: 80vw; max-height: 80vh; overflow: auto; }
+#closeLightbox { position: absolute; right: 0.5rem; top: 0.5rem; background: none; border: none; font-size: 2rem; cursor: pointer; }
+#fileLink.hidden { display: none; }

--- a/work-board/work-board.js
+++ b/work-board/work-board.js
@@ -1,0 +1,126 @@
+const state = {
+  items: [],
+  search: '',
+  filters: {}
+};
+
+document.getElementById('refreshBtn').addEventListener('click', fetchData);
+document.getElementById('searchInput').addEventListener('input', e => {
+  state.search = e.target.value.toLowerCase();
+  renderGallery();
+});
+document.getElementById('closeLightbox').addEventListener('click', closeLightbox);
+
+fetchData();
+setInterval(fetchData, 60000);
+
+async function fetchData() {
+  try {
+    const res = await fetch('./api/list-images');
+    state.items = await res.json();
+    state.filters = buildFilterSets(state.items);
+    renderFilters();
+    renderGallery();
+  } catch (err) {
+    console.error('Failed to fetch images', err);
+  }
+}
+
+function buildFilterSets(items) {
+  const fields = ['agileTeam', 'assetType', 'status', 'user'];
+  const sets = {};
+  fields.forEach(f => sets[f] = new Set());
+  items.forEach(item => fields.forEach(f => {
+    const value = item.metadata[f];
+    if (value) sets[f].add(value);
+  }));
+  return sets;
+}
+
+function renderFilters() {
+  const filtersEl = document.getElementById('filters');
+  filtersEl.innerHTML = '';
+  Object.entries(state.filters).forEach(([field, values]) => {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'filter-group';
+    const title = document.createElement('strong');
+    title.textContent = field;
+    wrapper.appendChild(title);
+    values.forEach(val => {
+      const label = document.createElement('label');
+      const input = document.createElement('input');
+      input.type = 'checkbox';
+      input.dataset.field = field;
+      input.value = val;
+      input.addEventListener('change', renderGallery);
+      label.appendChild(input);
+      label.append(` ${val}`);
+      wrapper.appendChild(label);
+    });
+    filtersEl.appendChild(wrapper);
+  });
+}
+
+function renderGallery() {
+  const activeFilters = {};
+  document.querySelectorAll('#filters input:checked').forEach(cb => {
+    const field = cb.dataset.field;
+    activeFilters[field] = activeFilters[field] || [];
+    activeFilters[field].push(cb.value);
+  });
+
+  const gallery = document.getElementById('gallery');
+  gallery.innerHTML = '';
+  state.items
+    .filter(item => passesFilters(item.metadata, activeFilters))
+    .filter(item => matchesSearch(item.metadata, state.search))
+    .forEach(item => gallery.appendChild(createCard(item)));
+}
+
+function passesFilters(meta, filters) {
+  return Object.entries(filters).every(([field, values]) => values.includes(meta[field]));
+}
+
+function matchesSearch(meta, query) {
+  if (!query) return true;
+  return Object.values(meta).some(v => (v || '').toString().toLowerCase().includes(query));
+}
+
+function createCard(item) {
+  const card = document.createElement('div');
+  card.className = 'card';
+  const img = document.createElement('img');
+  img.src = item.thumb;
+  img.alt = item.metadata.alt || '';
+  card.appendChild(img);
+  card.addEventListener('click', () => openLightbox(item));
+  return card;
+}
+
+function openLightbox(item) {
+  const lb = document.getElementById('lightbox');
+  document.getElementById('lightboxImg').src = item.url;
+
+  const metaList = document.getElementById('metaList');
+  metaList.innerHTML = '';
+  Object.entries(item.metadata).forEach(([k, v]) => {
+    if (!v) return;
+    const li = document.createElement('li');
+    li.innerHTML = `<strong>${k}:</strong> ${v}`;
+    metaList.appendChild(li);
+  });
+
+  const fileLink = document.getElementById('fileLink');
+  if (item.metadata.fileURL) {
+    fileLink.href = item.metadata.fileURL;
+    fileLink.classList.remove('hidden');
+  } else {
+    fileLink.classList.add('hidden');
+  }
+
+  lb.classList.remove('hidden');
+}
+
+function closeLightbox() {
+  document.getElementById('lightbox').classList.add('hidden');
+}


### PR DESCRIPTION
## Summary
- add work-board page with refresh, search, filters, and lightbox
- integrate Cloudinary via serverless API handler
- style work-board layout and overlay

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e0a3611ec832e9df0c4943ecab612